### PR TITLE
Add the Gilbert Baker flags

### DIFF
--- a/src/data/gradients.json
+++ b/src/data/gradients.json
@@ -4,6 +4,14 @@
     "colours": ["E40303", "FF8C00", "FFED00", "008026", "24408E", "732982"]
   },
   {
+    "name": "Gilbert Baker",
+    "colours": ["FF69B4", "E40303", "FF8C00", "FFED00", "008E00", "00C0C0", "400098", "8E008E"]
+  },
+  {
+    "name": "Baker 2017",
+    "colours": ["CD66FF", "FF69B4", "E40303", "FF8C00", "FFED00", "008E00", "00C0C0", "400098", "8E008E"]
+  },
+  {
     "name": "Philadelphia",
     "colours": [
       "000000",


### PR DESCRIPTION
This fork attempts to add the original and 2017 Gilbert Baker flags. I've named the second "Baker 2017" for brevity, but it can be edited. I don't actually have NPM set up on my machine right now, so I haven't actually tested it.